### PR TITLE
Added option for specifying Spring Boot version

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ import services.fileWriterService as fileWriter
 
 @click.command()
 @click.option('--generate', '-g', is_flag=True, help="Generate and build a spring server")
+@click.option('--spring-boot-version', '-v', default="2.1.9.RELEASE", help="Specify which version of Spring Boot to use")
 @click.option('--rest', '-a', nargs=3, help="Generate a full service, repo and model pipeline specifying: \n"
                                                              "project name\n"
                                                              "model name\n"
@@ -25,7 +26,7 @@ import services.fileWriterService as fileWriter
 @click.option('--controller', '-c',nargs=2, help="Generate a api controller specifying\n"
                                                  "project name\n"
                                                  "model name")
-def main(generate, rest, service, repo, model, controller):
+def main(generate, spring_boot_version, rest, service, repo, model, controller):
     if generate:
         project_name = click.prompt("Input project name")
         db_local = click.prompt("Is your db local? (y/yes or n/no)")
@@ -44,7 +45,7 @@ def main(generate, rest, service, repo, model, controller):
         click.echo("Making {} ...".format(project_name))
         directoryService.make_file_structure(project_name)
 
-        fileWriter.write_pom(project_name)
+        fileWriter.write_pom(project_name, spring_boot_version)
         fileWriter.write_application_properties(project_name, database_name, database_url)
         fileWriter.write_application_java(project_name)
 

--- a/services/fileWriterService.py
+++ b/services/fileWriterService.py
@@ -1,5 +1,4 @@
 import os
-import click
 
 
 def write_application_properties(project_name, database_name, database_url):
@@ -21,7 +20,7 @@ spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true\n\
 ")
 
 
-def write_pom(project_name):
+def write_pom(project_name, spring_boot_version):
     current_path = os.getcwd()
     pom = open(current_path + "/" + project_name + "/pom.xml", "w+")
     pom.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
@@ -37,7 +36,7 @@ def write_pom(project_name):
 \n\
         <groupId>org.springframework.boot</groupId>\n\
         <artifactId>spring-boot-starter-parent</artifactId>\n\
-        <version>2.0.5.RELEASE</version>\n\
+        <version>" + spring_boot_version + "</version>\n\
         <relativePath />\n\
         <!-- lookup parent from reposictory -->\n\
     </parent>\n\


### PR DESCRIPTION
I added an option --spring-boot-version for specifying the Spring Boot version to use, and set the default to 2.1.9.RELEASE, because that is the latest release at the time of writing. I saw you have hard coded the version as 2.0.5.RELEASE, but I think it is a better idea to specify it on the command line.

I thought about adding a function that fetches the latest version from Maven central and uses that, but then I thought that you might want to keep the CLI from depending on internet connectivity. This could still be added, however, and be used in case there is connectivity,